### PR TITLE
Update analytics card backgrounds

### DIFF
--- a/src/page-sections/dashboards/_common/Footer.tsx
+++ b/src/page-sections/dashboards/_common/Footer.tsx
@@ -16,6 +16,7 @@ import FlexBox from '@/components/flexbox/FlexBox'
 const StyledCard = styled(Card)(({ theme }) => ({
   gap: 16,
   padding: 24,
+  backgroundColor: '#171717',
   display: 'flex',
   flexWrap: 'wrap',
   alignItems: 'center',

--- a/src/page-sections/dashboards/analytics/ChartFilters.tsx
+++ b/src/page-sections/dashboards/analytics/ChartFilters.tsx
@@ -123,7 +123,7 @@ export default function ChartFilters({ type = 'area' }: ComponentProps) {
   })
 
   return (
-    <Card>
+    <Card sx={{ backgroundColor: '#171717' }}>
       <TopContentWrapper>
         {/* LIST SKELETON */}
         {isLoading || !chartData.length

--- a/src/page-sections/dashboards/analytics/CompleteGoal.tsx
+++ b/src/page-sections/dashboards/analytics/CompleteGoal.tsx
@@ -57,7 +57,7 @@ export default function CompleteGoal({ chart = 'bar' }: ComponentProps) {
   })
 
   return (
-    <Card>
+    <Card sx={{ backgroundColor: '#171717' }}>
       <Box p={3} pb={0} position="relative" zIndex={2}>
         <Title
           title={data[0]?.completed_goals}

--- a/src/page-sections/dashboards/analytics/CompleteRate.tsx
+++ b/src/page-sections/dashboards/analytics/CompleteRate.tsx
@@ -45,7 +45,7 @@ export default function CompleteRate() {
   })
 
   return (
-    <Card>
+    <Card sx={{ backgroundColor: '#171717' }}>
       <Box p={3} pb={0} position="relative" zIndex={2}>
         <Title
           title={`${data[0]?.rate}%`}

--- a/src/page-sections/dashboards/analytics/SalesByCountry.tsx
+++ b/src/page-sections/dashboards/analytics/SalesByCountry.tsx
@@ -76,7 +76,7 @@ export default function SalesByCountry({ chartHorizontal }: Props) {
   })
 
   return (
-    <Card sx={{ height: '100%', p: 3 }}>
+    <Card sx={{ height: '100%', p: 3, backgroundColor: '#171717' }}>
       <div>
         <Typography variant="body2" fontSize={18} fontWeight={500}>
           Sales by Country

--- a/src/page-sections/dashboards/analytics/SessionBrowser.tsx
+++ b/src/page-sections/dashboards/analytics/SessionBrowser.tsx
@@ -84,7 +84,7 @@ const SessionBrowser = React.memo(function SessionBrowser() {
   const series = useMemo(() => BROWSERS.map((b) => b.percentage), [BROWSERS])
 
   return (
-    <Card className="h-full">
+    <Card className="h-full" sx={{ backgroundColor: '#171717' }}>
       <Header>{t('Session by browser')}</Header>
 
       <Suspense fallback={<Box height={180} />}>

--- a/src/page-sections/dashboards/analytics/TopPerforming.tsx
+++ b/src/page-sections/dashboards/analytics/TopPerforming.tsx
@@ -16,7 +16,7 @@ import { useTopPerformingSites } from '@/hooks/useTopPermormingSites'
 export default function TopPerforming() {
   const { data: TOP_PERFORMING = [] } = useTopPerformingSites()
   return (
-    <Card sx={{ padding: 3, pb: 1 }}>
+    <Card sx={{ padding: 3, pb: 1, backgroundColor: '#171717' }}>
       <Box mb={3}>
         <Typography variant="body2" fontSize={18} fontWeight={500}>
           Top performing pages

--- a/src/page-sections/dashboards/analytics/TopQueries.tsx
+++ b/src/page-sections/dashboards/analytics/TopQueries.tsx
@@ -18,7 +18,7 @@ import { useTopQueries } from '@/hooks/useTopQueries'
 export default function TopQueries() {
   const { data: TOP_QUERIES = [] } = useTopQueries()
   return (
-    <Card sx={{ padding: 3, pb: 1 }}>
+    <Card sx={{ padding: 3, pb: 1, backgroundColor: '#171717' }}>
       <Box mb={3}>
         <Typography variant="body2" fontSize={18} fontWeight={500}>
           Top Queries

--- a/src/page-sections/dashboards/analytics/TopReferral.tsx
+++ b/src/page-sections/dashboards/analytics/TopReferral.tsx
@@ -93,7 +93,7 @@ export default function TopReferral() {
   ]
 
   return (
-    <Card sx={{ padding: 3, pb: 0 }}>
+    <Card sx={{ padding: 3, pb: 0, backgroundColor: '#171717' }}>
       <div>
         <Title
           title={1352}

--- a/src/page-sections/dashboards/analytics/TotalUsers.tsx
+++ b/src/page-sections/dashboards/analytics/TotalUsers.tsx
@@ -161,7 +161,7 @@ export default function TotalUsers() {
   })
 
   return (
-    <Card className="p-3 h-full">
+    <Card className="p-3 h-full" sx={{ backgroundColor: '#171717' }}>
       <TopStats>
         <Typography variant="body2" color="text.secondary">
           {t('Total Users')}


### PR DESCRIPTION
## Summary
- set card backgrounds to `#171717` in analytics-1 section

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_685571b3366c8333aac9e86b034ecb41